### PR TITLE
cache bust cover art url after chaning art

### DIFF
--- a/core/version/version.go
+++ b/core/version/version.go
@@ -3,7 +3,7 @@ package version
 import "zene/core/types"
 
 var Version = types.Version{
-	ServerVersion:          "4.6.0",
+	ServerVersion:          "4.7.0",
 	DatabaseVersion:        "151",
 	SubsonicApiVersion:     "1.16.1",
 	OpenSubsonicApiVersion: "1",

--- a/frontend/src/components/Album.vue
+++ b/frontend/src/components/Album.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { LoadingAttribute } from '../types'
 import type { SubsonicAlbum } from '../types/subsonicAlbum'
-import { useSessionStorage } from '@vueuse/core'
 import { getCoverArtUrl, onImageError, parseReleaseDate } from '~/composables/logic'
 import { useSearch } from '../composables/useSearch'
 
@@ -17,9 +16,9 @@ const props = defineProps({
 
 const router = useRouter()
 const { closeSearch } = useSearch()
-const updatedArt = useSessionStorage<string[]>('updatedArt', [])
 
 const showChangeArtModal = ref(false)
+const artUpdatedTime = ref<string | undefined>(undefined)
 
 const artistAndDate = computed(() => {
   const artist = props.album.displayAlbumArtist ?? props.album.displayArtist ?? props.album.artist ?? 'Unknown Artist'
@@ -52,11 +51,11 @@ const loading = computed<LoadingAttribute>(() => {
 })
 
 const coverArtUrlSm = computed(() => {
-  return getCoverArtUrl(props.album.id, 120)
+  return getCoverArtUrl(props.album.id, 120, artUpdatedTime.value)
 })
 
 const coverArtUrlMd = computed(() => {
-  return getCoverArtUrl(props.album.id, 200)
+  return getCoverArtUrl(props.album.id, 200, artUpdatedTime.value)
 })
 
 function navigateAlbum() {
@@ -71,7 +70,10 @@ function navigateArtist() {
 
 function actOnUpdatedArt() {
   showChangeArtModal.value = false
-  updatedArt.value.push(props.album.id)
+  // cache
+  fetch(getCoverArtUrl(props.album.id, 120), { method: 'POST', credentials: 'include' })
+  fetch(getCoverArtUrl(props.album.id, 200), { method: 'POST', credentials: 'include' })
+  artUpdatedTime.value = Date.now().toString()
 }
 </script>
 

--- a/frontend/src/composables/backendFetch.ts
+++ b/frontend/src/composables/backendFetch.ts
@@ -181,7 +181,7 @@ export async function fetchAlbums(type: string, size = 50, offset = 0, seed?: nu
   formData.append('type', type)
   formData.append('size', size.toString())
   formData.append('offset', offset.toString())
-  if (seed !== undefined && seed > 0) {
+  if (type === 'random' && seed !== undefined && seed > 0) {
     formData.append('seed', seed.toString())
   }
   const response = await openSubsonicFetchRequest<SubsonicAlbumListResponse>('getAlbumList', {

--- a/frontend/src/composables/logic.ts
+++ b/frontend/src/composables/logic.ts
@@ -1,8 +1,5 @@
 import type { ReleaseDate } from '../types/subsonicAlbum'
-import { useSessionStorage } from '@vueuse/core'
 import dayjs from 'dayjs'
-
-const updatedArt = useSessionStorage<string[]>('updatedArt', [])
 
 export function niceDate(dateString: string): string {
   const date = dayjs(dateString)
@@ -22,10 +19,9 @@ export function formatTimeFromSeconds(time: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
-export function getCoverArtUrl(musicbrainzId: string, size = 400): string {
-  if (updatedArt.value.includes(musicbrainzId)) {
-    const timestamp = Date.now()
-    return `/share/img/${musicbrainzId}?size=${size}&t=${timestamp}`
+export function getCoverArtUrl(musicbrainzId: string, size = 400, timeUpdated?: string): string {
+  if (timeUpdated != null) {
+    return `/share/img/${musicbrainzId}?size=${size}&time=${timeUpdated}`
   }
   return `/share/img/${musicbrainzId}?size=${size}`
 }


### PR DESCRIPTION
This pull request introduces improvements to the album cover art update and caching mechanism in the frontend, and also includes a minor backend version bump. The main change is a shift from using session storage to track updated album art to using a timestamp-based cache-busting approach, which ensures that updated cover art is correctly fetched without relying on client-side storage. Additionally, there is a small fix to the album fetching logic and a version update.

**Frontend: Album Art Update & Caching Improvements**
- Replaced the use of session storage (`useSessionStorage`) for tracking updated album art with a timestamp-based approach (`artUpdatedTime`), allowing cache-busting by appending a `time` query parameter to the cover art URL. This ensures users see the latest cover art after an update without depending on session storage. (`frontend/src/components/Album.vue`, `frontend/src/composables/logic.ts`) [[1]](diffhunk://#diff-60b52a64aa13a53da32bccb3cfdf4e0dd6ad38b598437eb0a4a110725b6a1a46L4) [[2]](diffhunk://#diff-60b52a64aa13a53da32bccb3cfdf4e0dd6ad38b598437eb0a4a110725b6a1a46L20-R21) [[3]](diffhunk://#diff-60b52a64aa13a53da32bccb3cfdf4e0dd6ad38b598437eb0a4a110725b6a1a46L55-R58) [[4]](diffhunk://#diff-60b52a64aa13a53da32bccb3cfdf4e0dd6ad38b598437eb0a4a110725b6a1a46L74-R76) [[5]](diffhunk://#diff-b2bebfd07ab4747594d4fc636f258d1778be562f0949477d67a9279245049a69L2-L6) [[6]](diffhunk://#diff-b2bebfd07ab4747594d4fc636f258d1778be562f0949477d67a9279245049a69L25-R24)

**Frontend: Miscellaneous Fixes**
- Corrected the logic in `fetchAlbums` to only include the `seed` parameter for random album requests, preventing unnecessary parameters for other types. (`frontend/src/composables/backendFetch.ts`)

**Backend: Version Update**
- Bumped the `ServerVersion` from `4.6.0` to `4.7.0` in `core/version/version.go`.