### PR TITLE
Styling/20260103

### DIFF
--- a/core/version/version.go
+++ b/core/version/version.go
@@ -3,7 +3,7 @@ package version
 import "zene/core/types"
 
 var Version = types.Version{
-	ServerVersion:          "26.2.1",
+	ServerVersion:          "26.3.0",
 	DatabaseVersion:        "151",
 	SubsonicApiVersion:     "1.16.1",
 	OpenSubsonicApiVersion: "1",

--- a/cspell.json
+++ b/cspell.json
@@ -29,6 +29,7 @@
         "ctx",
         "Deezer",
         "djherbis",
+        "dvh",
         "dvw",
         "env",
         "Feishin",

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -47,6 +47,7 @@ declare module 'vue' {
     IconNrkSearch: typeof import('~icons/nrk/search')['default']
     IconNrkSettings: typeof import('~icons/nrk/settings')['default']
     IconNrkTrash: typeof import('~icons/nrk/trash')['default']
+    IconNrkUiClose: typeof import('~icons/nrk/ui-close')['default']
     IconNrkUserLoggedin: typeof import('~icons/nrk/user-loggedin')['default']
     ImageSelector: typeof import('./src/components/ImageSelector.vue')['default']
     ImageSelectorImage: typeof import('./src/components/ImageSelectorImage.vue')['default']

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="h-screen flex background-1 text-muted md:grid md:grid-cols-[200px_1fr]">
+  <div class="h-screen flex background-1 text-muted lg:grid lg:grid-cols-[200px_1fr]">
     <Navbar />
     <main class="flex flex-1 flex-col overflow-y-auto">
-      <div class="flex flex-col overflow-y-auto p-3 space-y-4 md:p-6 md:space-y-6">
+      <div class="flex flex-col overflow-y-auto p-3 space-y-4 lg:p-6 lg:space-y-6">
         <HeaderAndSearch />
         <RouterView />
       </div>

--- a/frontend/src/components/Album.vue
+++ b/frontend/src/components/Album.vue
@@ -98,7 +98,7 @@ function actOnUpdatedArt() {
         />
       </div>
       <div class="max-w-150px">
-        <div v-if="showArtist" class="truncate text-nowrap text-lg text-primary md:text-base">
+        <div v-if="showArtist" class="truncate text-nowrap text-lg text-primary lg:text-base">
           {{ album.title || album.name }}
         </div>
         <div v-if="showArtist && showDate" class="cursor-pointer truncate text-nowrap text-sm" @click="navigateArtist()">
@@ -107,38 +107,35 @@ function actOnUpdatedArt() {
         <div v-else-if="showArtist && !showDate" class="cursor-pointer truncate text-nowrap text-sm" @click="navigateArtist()">
           {{ artist }}
         </div>
-        <div v-if="!showArtist && showDate" class="cursor-pointer truncate text-nowrap text-sm md:text-base" @click="navigateArtist()">
+        <div v-if="!showArtist && showDate" class="cursor-pointer truncate text-nowrap text-sm lg:text-base" @click="navigateArtist()">
           {{ albumAndDate }}
         </div>
-        <div v-else-if="!showArtist && !showDate" class="cursor-pointer truncate text-nowrap text-sm md:text-base" @click="navigateArtist()">
+        <div v-else-if="!showArtist && !showDate" class="cursor-pointer truncate text-nowrap text-sm lg:text-base" @click="navigateArtist()">
           {{ album.title }}
         </div>
       </div>
     </div>
-    <div v-else-if="props.size === 'md'" class="group corner-cut-large relative background-grad-2 p-3 md:p-10">
-      <div class="h-full flex flex-col items-center gap-2 md:flex-row md:gap-6">
+    <!-- medium -->
+    <div v-else-if="props.size === 'md'" class="group corner-cut relative background-grad-2 p-3 lg:(corner-cut-large p-8)">
+      <div class="h-30 flex flex-row gap-2 lg:h-52 lg:gap-6">
         <img
           :src="coverArtUrlMd"
-          class="aspect-square size-24 cursor-pointer border-muted md:size-52"
+          class="h-30 cursor-pointer border-muted lg:h-52"
           loading="lazy"
-          width="200"
-          height="200"
           @error="onImageError"
           @click="navigateAlbum()"
         >
-        <div class="h-24 flex flex-col justify-between text-center md:h-52 md:gap-4 md:text-left">
-          <div class="cursor-pointer text-lg font-bold md:text-4xl" @click="navigateAlbum()">
+        <div class="my-auto flex flex-col gap-1 text-left lg:gap-4">
+          <div class="cursor-pointer text-xl font-bold lg:text-4xl" @click="navigateAlbum()">
             {{ album.name }}
           </div>
-          <div class="cursor-pointer text-sm md:text-xl" @click="navigateArtist()">
+          <div class="cursor-pointer text-lg lg:text-xl" @click="navigateArtist()">
             {{ artistAndDate }}
           </div>
-          <div v-if="album.genres?.length > 0" class="flex justify-center gap-2 overflow-hidden md:flex-nowrap md:justify-start">
+          <div v-if="album.genres?.length > 0" class="hidden lg:(block flex flex-nowrap justify-start gap-2 overflow-hidden)">
             <GenreBottle v-for="genre in album.genres.filter(g => g.name !== '').slice(0, 8)" :key="genre.name" :genre="genre.name" />
           </div>
-          <div class="flex justify-center md:justify-start">
-            <PlayButton :album="album" />
-          </div>
+          <PlayButton class="flex justify-start" :album="album" />
         </div>
       </div>
       <!-- Change Album Art section -->
@@ -147,7 +144,9 @@ function actOnUpdatedArt() {
           class="opacity-0 group-hover:opacity-100"
           @click="showChangeArtModal = true"
         >
-          Change Album Art
+          <div>
+            Change Album Art
+          </div>
         </ZButton>
         <ChangeAlbumArt
           v-if="showChangeArtModal"

--- a/frontend/src/components/Album.vue
+++ b/frontend/src/components/Album.vue
@@ -98,7 +98,7 @@ function actOnUpdatedArt() {
         />
       </div>
       <div class="max-w-150px">
-        <div v-if="showArtist" class="truncate text-nowrap text-sm text-primary md:text-base">
+        <div v-if="showArtist" class="truncate text-nowrap text-lg text-primary md:text-base">
           {{ album.title || album.name }}
         </div>
         <div v-if="showArtist && showDate" class="cursor-pointer truncate text-nowrap text-sm" @click="navigateArtist()">

--- a/frontend/src/components/Albums.vue
+++ b/frontend/src/components/Albums.vue
@@ -164,7 +164,7 @@ onBeforeMount(async () => {
         :album="album"
         :index="index"
         size="sm"
-        class="transition duration-200 hover:scale-100 md:scale-95"
+        class="transition duration-200 hover:scale-100 lg:scale-95"
         :show-date="false"
       />
     </div>

--- a/frontend/src/components/Albums.vue
+++ b/frontend/src/components/Albums.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   limit: { type: Number, default: 30 },
   offset: { type: Number, default: 0 },
   scrollable: { type: Boolean, default: false },
-  twoRowsOnly: { type: Boolean, default: false },
+  limitRows: { type: Boolean, default: false },
   sortKey: { type: String, default: 'currentAlbumOrder' },
 })
 
@@ -37,10 +37,15 @@ const sortOptions = [
 const { height: firstAlbumHeight } = useElementSize(firstAlbumElement)
 
 const heightStyle = computed(() => {
-  if (props.twoRowsOnly && firstAlbumHeight.value > 0) {
-    return `max-height: calc(${(firstAlbumHeight.value * 2) + 24}px);`
+  if (props.limitRows && firstAlbumHeight.value > 0) {
+    const smHeight = (firstAlbumHeight.value * 3) + 24
+    const lgHeight = (firstAlbumHeight.value * 2) + 24
+    return {
+      'maxHeight': `${smHeight}px`,
+      '--albums-lg-max-height': `${lgHeight}px`,
+    }
   }
-  return ''
+  return {}
 })
 
 let fetchType: string
@@ -168,3 +173,11 @@ onBeforeMount(async () => {
     </div>
   </div>
 </template>
+
+<style scoped>
+@media (min-width: 1024px) {
+  .auto-grid-6 {
+    max-height: var(--albums-lg-max-height, none) !important;
+  }
+}
+</style>

--- a/frontend/src/components/ArtistThumb.vue
+++ b/frontend/src/components/ArtistThumb.vue
@@ -45,7 +45,7 @@ function navigate() {
       />
     </div>
     <div class="max-w-150px">
-      <div class="truncate text-center text-nowrap text-sm text-primary md:text-base">
+      <div class="truncate text-center text-nowrap text-sm text-primary lg:text-base">
         {{ artist.name }}
       </div>
     </div>

--- a/frontend/src/components/Artists.vue
+++ b/frontend/src/components/Artists.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   limit: { type: Number, default: 30 },
   offset: { type: Number, default: 0 },
   scrollable: { type: Boolean, default: false },
-  twoRowsOnly: { type: Boolean, default: false },
+  limitRows: { type: Boolean, default: false },
   sortKey: { type: String, default: 'currentArtistOrder' },
 })
 
@@ -35,6 +35,18 @@ const sortOptions = [
   { label: 'Alphabetical', emitValue: 'alphabetical' },
   { label: 'Starred', emitValue: 'starred' },
 ]
+
+const heightStyle = computed(() => {
+  if (props.limitRows) {
+    const smHeight = (174 * 3) + 48
+    const lgHeight = (174 * 2) + 24
+    return {
+      'maxHeight': `${smHeight}px`,
+      '--albums-lg-max-height': `${lgHeight}px`,
+    }
+  }
+  return {}
+})
 
 watch(observerIsVisible, (newValue) => {
   if (newValue && props.scrollable) {
@@ -120,7 +132,7 @@ onBeforeMount(async () => {
     <div
       v-if="artists.length > 0"
       class="auto-grid-6 overflow-hidden"
-      :style="twoRowsOnly ? `max-height: calc(${174 * 2 + 24}px);` : ''"
+      :style="heightStyle"
     >
       <ArtistThumb
         v-for="(artist, index) in artists"
@@ -136,3 +148,11 @@ onBeforeMount(async () => {
     </div>
   </div>
 </template>
+
+<style scoped>
+@media (min-width: 1024px) {
+  .auto-grid-6 {
+    max-height: var(--albums-lg-max-height, none) !important;
+  }
+}
+</style>

--- a/frontend/src/components/Artists.vue
+++ b/frontend/src/components/Artists.vue
@@ -139,7 +139,7 @@ onBeforeMount(async () => {
         :key="artist.musicBrainzId"
         :artist="artist"
         :index="index"
-        class="transition duration-200 hover:scale-100 md:scale-95"
+        class="mx-auto transition duration-200 md:(mx-none scale-95) hover:scale-100"
         @click="() => router.push(`/artists/${artist.musicBrainzId}`)"
       />
     </div>

--- a/frontend/src/components/Artists.vue
+++ b/frontend/src/components/Artists.vue
@@ -139,7 +139,7 @@ onBeforeMount(async () => {
         :key="artist.musicBrainzId"
         :artist="artist"
         :index="index"
-        class="mx-auto transition duration-200 md:(mx-none scale-95) hover:scale-100"
+        class="mx-auto transition duration-200 lg:(mx-none scale-95) hover:scale-100"
         @click="() => router.push(`/artists/${artist.musicBrainzId}`)"
       />
     </div>

--- a/frontend/src/components/ChangeAlbumArt.vue
+++ b/frontend/src/components/ChangeAlbumArt.vue
@@ -79,8 +79,8 @@ onMounted(() => {
     <div class="fixed inset-0 z-50 flex items-center justify-center backdrop-blur-lg">
       <div class="relative w-full flex flex-col gap-4 border-1 border-zshade-500 border-solid background-3 p-4 lg:w-80dvw">
         <div class="flex flex-row items-center justify-center gap-4">
-          <ZButton aria-label="Close" @click="$emit('close')">
-            X
+          <ZButton :size12="true" aria-label="Close" hover-text="Close" @click="$emit('close')">
+            <icon-nrk-close class="size-full text-primary" />
           </ZButton>
           <p class="text-lg text-primary font-bold">
             Change Album Art

--- a/frontend/src/components/FooterPlayer.vue
+++ b/frontend/src/components/FooterPlayer.vue
@@ -158,9 +158,9 @@ async function handleGetRandomTracks() {
   <footer
     class="sticky bottom-0 mt-auto w-full border-0 border-t-1 border-zshade-400 border-zshade-600 border-solid background-2"
   >
-    <div class="flex flex-col items-center px-2 md:flex-row space-y-2 md:px-4 md:space-x-2 md:space-y-0">
+    <div class="flex flex-col items-center px-2 lg:flex-row space-y-2 lg:px-4 lg:space-x-2 lg:space-y-0">
       <div
-        class="h-full w-full flex flex-grow flex-col items-center justify-center py-2 space-y-2 md:py-2 md:space-y-2"
+        class="h-full w-full flex flex-grow flex-col items-center justify-center py-2 space-y-2 lg:py-2 lg:space-y-2"
       >
         <PlayerAudio
           ref="playerAudio"
@@ -189,7 +189,7 @@ async function handleGetRandomTracks() {
         </div>
       </div>
 
-      <div class="flex flex-row items-center gap-x-3 md:gap-x-4">
+      <div class="flex flex-row items-center gap-x-3 lg:gap-x-4">
         <!-- <PlayerCastButton /> -->
         <PlayerLyricsButton
           :current-time="currentTime"

--- a/frontend/src/components/HeaderAndSearch.vue
+++ b/frontend/src/components/HeaderAndSearch.vue
@@ -36,13 +36,15 @@ const toggleDark = useToggle(isDark)
         </div>
       </div>
       <div id="user-and-settings" class="flex items-center justify-center gap-4 text-muted">
-        <div class="icon" @click="toggleDark()">
+        <abbr :title="isDark ? 'Light mode' : 'Dark mode'" class="icon" @click="toggleDark()">
           <icon-fluent-dark-theme-24-regular class="text-2xl" />
-        </div>
-        <SettingsDropDown class="icon" />
-        <div class="icon">
+        </abbr>
+        <abbr title="Settings">
+          <SettingsDropDown class="icon" />
+        </abbr>
+        <abbr title="User" class="icon">
           <icon-nrk-user-loggedin class="text-2xl" />
-        </div>
+        </abbr>
       </div>
     </div>
     <SearchResults />

--- a/frontend/src/components/HeaderAndSearch.vue
+++ b/frontend/src/components/HeaderAndSearch.vue
@@ -12,14 +12,14 @@ const toggleDark = useToggle(isDark)
 
 <template>
   <header>
-    <div class="flex gap-2 p-2 md:gap-4">
+    <div class="flex gap-2 p-2 lg:gap-4">
       <!-- Mobile hamburger menu -->
-      <div class="flex items-center justify-center md:hidden">
+      <div class="flex items-center justify-center lg:hidden">
         <icon-nrk-list class="text-2xl" @click="toggleMobileNav()" />
       </div>
 
       <div class="flex flex-grow items-center justify-center">
-        <div class="relative w-full md:(max-w-md w-1/2)">
+        <div class="relative w-full lg:(max-w-md w-1/2)">
           <span class="absolute inset-y-0 left-0 h-full flex items-center justify-center pl-3 text-muted">
             <icon-nrk-search class="text-xl" />
           </span>
@@ -28,7 +28,7 @@ const toggleDark = useToggle(isDark)
             v-model="searchInput"
             placeholder="Type here to search"
             type="text"
-            class="border-1 border-primary2 background-2 py-2 pl-10 focus:border-primary2 dark:border-opacity-60 focus:border-solid md:pr-full focus:shadow-primary2 hover:shadow-lg focus:outline-none"
+            class="border-1 border-primary2 background-2 py-2 pl-10 focus:border-primary2 dark:border-opacity-60 focus:border-solid lg:pr-full focus:shadow-primary2 hover:shadow-lg focus:outline-none"
             @change="getSearchResults()"
             @input="getSearchResults()"
             @keydown.escape="searchInput = ''"

--- a/frontend/src/components/HeaderAndSearch.vue
+++ b/frontend/src/components/HeaderAndSearch.vue
@@ -19,7 +19,7 @@ const toggleDark = useToggle(isDark)
       </div>
 
       <div class="flex flex-grow items-center justify-center">
-        <div class="relative max-w-xs w-full md:max-w-md md:w-1/2">
+        <div class="relative w-full md:(max-w-md w-1/2)">
           <span class="absolute inset-y-0 left-0 h-full flex items-center justify-center pl-3 text-muted">
             <icon-nrk-search class="text-xl" />
           </span>
@@ -35,7 +35,7 @@ const toggleDark = useToggle(isDark)
           >
         </div>
       </div>
-      <div id="user-and-settings" class="flex gap-4 text-muted">
+      <div id="user-and-settings" class="flex items-center justify-center gap-4 text-muted">
         <div class="icon" @click="toggleDark()">
           <icon-fluent-dark-theme-24-regular class="text-2xl" />
         </div>

--- a/frontend/src/components/HeroAlbum.vue
+++ b/frontend/src/components/HeroAlbum.vue
@@ -61,18 +61,18 @@ onBeforeMount(async () => {
     >
       <div class="h-full w-full flex items-center justify-between background-grad-2 backdrop-blur-md">
         <Album :album="albumArray[index]" size="md" />
-        <div id="album-dice" class="corner-cut absolute right-0 top-0 m-3 mb-auto flex gap-2 background-2 p-3 md:m-6 md:mb-auto md:p-2">
+        <div id="album-dice" class="corner-cut absolute right-0 top-0 m-3 mb-auto flex gap-2 background-2 p-3 lg:m-6 lg:mb-auto lg:p-2">
           <icon-nrk-chevron-left
-            class="cursor-pointer text-2xl opacity-80 hover:scale-105 md:text-3xl hover:text-primary2 active:opacity-100"
+            class="cursor-pointer text-2xl opacity-80 hover:scale-105 lg:text-3xl hover:text-primary2 active:opacity-100"
             @click="prevIndex"
           />
           <icon-nrk-dice-3
-            class="cursor-pointer text-2xl opacity-80 hover:scale-105 md:text-3xl hover:text-primary2 active:opacity-100"
+            class="cursor-pointer text-2xl opacity-80 hover:scale-105 lg:text-3xl hover:text-primary2 active:opacity-100"
             :class="{ shake: isShaking }"
             @click="handleDiceClick()"
           />
           <icon-nrk-chevron-right
-            class="cursor-pointer text-2xl opacity-80 hover:scale-105 md:text-3xl hover:text-primary2 active:opacity-100"
+            class="cursor-pointer text-2xl opacity-80 hover:scale-105 lg:text-3xl hover:text-primary2 active:opacity-100"
             @click="nextIndex"
           />
         </div>

--- a/frontend/src/components/LyricsModal.vue
+++ b/frontend/src/components/LyricsModal.vue
@@ -10,30 +10,38 @@ defineEmits(['close'])
 </script>
 
 <template>
-  <teleport to="body">
-    <div class="fixed inset-0 z-50 flex justify-center overflow-y-scroll bg-white/40 p-4 backdrop-blur-xl dark:bg-black/40">
-      <ZButton class="absolute right-4 top-4" @click="$emit('close')">
-        Close
-      </ZButton>
-      <div v-if="lyrics.length > 0">
-        <div class="flex flex-col gap-2 text-center text-muted">
-          <div
-            v-for="(line, index) in lyrics" :key="index"
-            :class="{
-              'bg-green/20': line.start && line.start <= currentSeconds && (lyrics[index + 1]?.start ?? 0) > currentSeconds,
-              '': (line.start ?? 0) >= currentSeconds,
-            }"
-          >
-            {{ (line.start ?? 0) <= currentSeconds && (lyrics[index + 1]?.start ?? 0) > currentSeconds
-              ? '▶️ '
-              : '' }}
-            <span>{{ line.value }}</span>
+  <div>
+    <teleport to="body">
+      <div class="fixed inset-0 z-50 overflow-y-scroll bg-white/40 p-4 backdrop-blur-xl dark:bg-black/40">
+        <div class="flex justify-center">
+          <div v-if="lyrics.length > 0">
+            <div class="flex flex-col gap-2 text-center text-lg text-muted lg:text-base">
+              <div
+                v-for="(line, index) in lyrics" :key="index"
+                :class="{
+                  'bg-green/20': line.start && line.start <= currentSeconds && (lyrics[index + 1]?.start ?? 0) > currentSeconds,
+                  '': (line.start ?? 0) >= currentSeconds,
+                }"
+              >
+                {{ (line.start ?? 0) <= currentSeconds && (lyrics[index + 1]?.start ?? 0) > currentSeconds
+                  ? '▶️ '
+                  : '' }}
+                <span>{{ line.value }}</span>
+              </div>
+            </div>
           </div>
+          <p v-else class="flex flex-col gap-2 text-center">
+            'No lyrics available.'
+          </p>
         </div>
       </div>
-      <p v-else class="flex flex-col gap-2 text-center">
-        'No lyrics available.'
-      </p>
-    </div>
-  </teleport>
+    </teleport>
+    <teleport to="body">
+      <div class="absolute right-4 top-4 z-51 lg:right-8">
+        <ZButton class="" @click="$emit('close')">
+          Close
+        </ZButton>
+      </div>
+    </teleport>
+  </div>
 </template>

--- a/frontend/src/components/NavLink.vue
+++ b/frontend/src/components/NavLink.vue
@@ -39,7 +39,7 @@ function handleLinkClick() {
         'group-hover/navlink:opacity-50 text-secondary1': currentRoute !== routeProp && !currentRoute.startsWith(`${routeProp}/`),
       }"
     />
-    {{ routeName }}
+    <span class="text-2xl lg:text-lg">{{ routeName }}</span>
   </RouterLink>
 </template>
 

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -24,6 +24,7 @@ const { isMobileNavOpen, closeMobileNav } = useNavbar()
     <div class="mb-4 flex justify-start lg:hidden">
       <ZButton
         :size12="true"
+        hover-text="Close Menu"
         @click="closeMobileNav()"
       >
         <icon-nrk-close class="text-2xl" />

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -14,7 +14,7 @@ const { isMobileNavOpen, closeMobileNav } = useNavbar()
 
   <!-- Navbar -->
   <aside
-    class="fixed inset-y-0 left-0 z-50 w-64 flex flex-col background-2 p-4 transition-transform duration-300 ease-in-out md:relative md:w-auto md:flex"
+    class="fixed inset-y-0 left-0 z-50 w-full flex flex-col background-2 p-4 transition-transform duration-300 ease-in-out md:relative md:w-auto md:flex"
     :class="{
       'translate-x-0': isMobileNavOpen,
       '-translate-x-full md:translate-x-0': !isMobileNavOpen,
@@ -22,28 +22,26 @@ const { isMobileNavOpen, closeMobileNav } = useNavbar()
   >
     <!-- Mobile close button -->
     <div class="mb-4 flex justify-start md:hidden">
-      <button
-        class="size-12"
+      <ZButton
+        :size12="true"
         @click="closeMobileNav()"
       >
         <icon-nrk-close class="text-2xl" />
-      </button>
+      </ZButton>
     </div>
 
     <div class="flex flex-col space-y-6">
       <RouterLink class="flex items-center gap-x-2 px-2" to="/">
         <img
-          class="size-12 opacity-90"
+          class="size-20 opacity-90 lg:size-12"
           src="/minidisk.svg"
           alt="Logo"
-          width="48"
-          height="48"
         />
-        <div class="text-2xl text-muted font-bold">
+        <div class="text-3xl text-muted font-bold lg:text-2xl">
           Zene
         </div>
       </RouterLink>
-      <nav class="flex flex-col gap-y-4 px-2 lg:text-xl">
+      <nav class="flex flex-col gap-y-4 px-2">
         <NavLink route-name="Home" route-prop="/" />
         <NavLink route-name="Albums" route-prop="/albums" />
         <NavLink route-name="Artists" route-prop="/artists" />
@@ -55,7 +53,7 @@ const { isMobileNavOpen, closeMobileNav } = useNavbar()
         <NavLink route-name="Queue" route-prop="/queue" />
       </nav>
     </div>
-    <NavArt class="mt-auto" />
+    <NavArt class="mt-auto hidden lg:block" />
   </aside>
 </template>
 

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -8,20 +8,20 @@ const { isMobileNavOpen, closeMobileNav } = useNavbar()
   <!-- Mobile overlay backdrop -->
   <div
     v-if="isMobileNavOpen"
-    class="fixed inset-0 z-40 md:hidden"
+    class="fixed inset-0 z-40 lg:hidden"
     @click="closeMobileNav"
   />
 
   <!-- Navbar -->
   <aside
-    class="fixed inset-y-0 left-0 z-50 w-full flex flex-col background-2 p-4 transition-transform duration-300 ease-in-out md:relative md:w-auto md:flex"
+    class="fixed inset-y-0 left-0 z-50 w-full flex flex-col background-2 p-4 transition-transform duration-300 ease-in-out lg:relative lg:w-auto lg:flex"
     :class="{
       'translate-x-0': isMobileNavOpen,
-      '-translate-x-full md:translate-x-0': !isMobileNavOpen,
+      '-translate-x-full lg:translate-x-0': !isMobileNavOpen,
     }"
   >
     <!-- Mobile close button -->
-    <div class="mb-4 flex justify-start md:hidden">
+    <div class="mb-4 flex justify-start lg:hidden">
       <ZButton
         :size12="true"
         @click="closeMobileNav()"

--- a/frontend/src/components/PlayButton.vue
+++ b/frontend/src/components/PlayButton.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { SubsonicAlbum } from '~/types/subsonicAlbum'
 import type { SubsonicIndexArtist } from '~/types/subsonicArtist'
+import type { SubsonicPodcastEpisode } from '~/types/subsonicPodcasts'
 import type { SubsonicSong } from '~/types/subsonicSong'
 import { usePlaybackQueue } from '~/composables/usePlaybackQueue'
 
@@ -8,6 +9,7 @@ defineProps({
   artist: { type: Object as PropType<SubsonicIndexArtist>, required: false },
   album: { type: Object as PropType<SubsonicAlbum>, required: false },
   track: { type: Object as PropType<SubsonicSong>, required: false },
+  podcast: { type: Object as PropType<SubsonicPodcastEpisode>, required: false },
 })
 
 const { play } = usePlaybackQueue()
@@ -19,7 +21,8 @@ const { play } = usePlaybackQueue()
       :primary="true"
       class="group/button"
       :size12="true"
-      @click="play(artist, album, track)"
+      :hover-text="`Play ${track ? 'track' : album ? 'album' : artist ? 'artist' : podcast ? 'podcast' : ''}`"
+      @click="play(artist, album, track, podcast)"
     >
       <icon-nrk-media-play
         class="footer-icon"

--- a/frontend/src/components/PlayerLyricsButton.vue
+++ b/frontend/src/components/PlayerLyricsButton.vue
@@ -39,7 +39,7 @@ onMounted(async () => {
   <div>
     <button
       id="lyrics"
-      class="h-10 w-10 flex cursor-pointer items-center justify-center border-none bg-white/0 text-muted font-semibold outline-none md:h-12 md:w-12 sm:h-10 sm:w-10"
+      class="h-10 w-10 flex cursor-pointer items-center justify-center border-none bg-white/0 text-muted font-semibold outline-none lg:h-12 lg:w-12 sm:h-10 sm:w-10"
       @click="showLyrics = !showLyrics"
     >
       <icon-nrk-mening class="footer-icon" />

--- a/frontend/src/components/PlayerMediaControls.vue
+++ b/frontend/src/components/PlayerMediaControls.vue
@@ -44,6 +44,7 @@ onKeyStroke('MediaStop', (e) => {
       class="group/button"
       :primary="true"
       :size12="true"
+      hover-text="Play/Pause"
       @click="emits('togglePlayback')"
     >
       <icon-nrk-media-play v-if="!isPlaying" class="footer-icon" />

--- a/frontend/src/components/PlayerMediaControls.vue
+++ b/frontend/src/components/PlayerMediaControls.vue
@@ -29,7 +29,7 @@ onKeyStroke('MediaStop', (e) => {
 </script>
 
 <template>
-  <div class="mt-2 flex flex-row items-center justify-center gap-x-2 md:mt-2 md:gap-x-4 sm:gap-x-2">
+  <div class="mt-2 flex flex-row items-center justify-center gap-x-2 lg:mt-2 lg:gap-x-4 sm:gap-x-2">
     <button id="repeat" class="media-control-button" @click="emits('stopPlayback')">
       <icon-nrk-media-stop class="footer-icon" />
     </button>
@@ -67,6 +67,6 @@ onKeyStroke('MediaStop', (e) => {
 
 <style scoped>
 .media-control-button {
-  @apply h-10 w-10 flex cursor-pointer items-center justify-center border-none bg-white/0 font-semibold outline-none md:h-12 md:w-12 sm:h-10 sm:w-10;
+  @apply h-10 w-10 flex cursor-pointer items-center justify-center border-none bg-white/0 font-semibold outline-none lg:h-12 lg:w-12 sm:h-10 sm:w-10;
 }
 </style>

--- a/frontend/src/components/PlayerProgressBar.vue
+++ b/frontend/src/components/PlayerProgressBar.vue
@@ -41,18 +41,18 @@ function seek(event: Event) {
 </script>
 
 <template>
-  <div v-if="currentlyPlayingTrack.duration || currentlyPlayingPodcastEpisode.duration" class="max-w-xs w-full flex flex-row items-center gap-2 lg:max-w-200 md:max-w-lg sm:max-w-md md:gap-2">
-    <span id="currentTime" class="w-10 text-right text-sm text-muted md:w-12 sm:w-10 sm:text-sm">
+  <div v-if="currentlyPlayingTrack.duration || currentlyPlayingPodcastEpisode.duration" class="max-w-xs w-full flex flex-row items-center gap-2 lg:max-w-200 lg:max-w-lg sm:max-w-md lg:gap-2">
+    <span id="currentTime" class="w-10 text-right text-sm text-muted lg:w-12 sm:w-10 sm:text-sm">
       {{ currentTime }}
     </span>
     <input
       type="range"
-      class="h-2 w-full cursor-pointer background-2 accent-primary1 md:h-1"
+      class="h-2 w-full cursor-pointer background-2 accent-primary1 lg:h-1"
       :max="inputDuration"
       :value="currentTimeInSeconds"
       @input="seek($event)"
     />
-    <span id="duration" class="w-10 text-sm text-muted md:w-12 sm:w-10 sm:text-sm">
+    <span id="duration" class="w-10 text-sm text-muted lg:w-12 sm:w-10 sm:text-sm">
       {{ duration }}
     </span>
   </div>

--- a/frontend/src/components/PlayerVolumeSlider.vue
+++ b/frontend/src/components/PlayerVolumeSlider.vue
@@ -13,7 +13,7 @@ function handleInput(e: Event) {
 </script>
 
 <template>
-  <div v-if="audioRef" id="volume-range-input" class="flex flex-row cursor-pointer items-center gap-2 md:gap-2">
+  <div v-if="audioRef" id="volume-range-input" class="flex flex-row cursor-pointer items-center gap-2 lg:gap-2">
     <div @click="emits('toggleMute')">
       <icon-nrk-media-volume-3 v-if="audioRef.volume > 0.66" class="text-sm text-muted sm:text-sm" />
       <icon-nrk-media-volume-2 v-else-if="audioRef.volume > 0.33" class="text-sm text-muted sm:text-sm" />
@@ -21,7 +21,7 @@ function handleInput(e: Event) {
     </div>
     <input
       type="range"
-      class="h-2 w-20 cursor-pointer background-1 accent-primary2 md:w-30 sm:w-24 active:accent-primary1"
+      class="h-2 w-20 cursor-pointer background-1 accent-primary2 lg:w-30 sm:w-24 active:accent-primary1"
       max="1"
       step="0.01"
       :value="modelValue"

--- a/frontend/src/components/PodcastEpisode.vue
+++ b/frontend/src/components/PodcastEpisode.vue
@@ -3,7 +3,6 @@ import type { SubsonicPodcastChannelsResponse } from '~/types/subsonic'
 import type { SubsonicPodcastEpisode } from '~/types/subsonicPodcasts'
 import { downloadMediaBlob, openSubsonicFetchRequest } from '~/composables/backendFetch'
 import { formatTimeFromSeconds } from '~/composables/logic'
-import { usePlaybackQueue } from '~/composables/usePlaybackQueue'
 import { deleteStoredEpisode, episodeIsStored, setStoredEpisode } from '~/stores/usePodcastStore'
 
 const props = defineProps({
@@ -13,7 +12,6 @@ const props = defineProps({
 
 const emits = defineEmits(['updateEpisodeStatus'])
 
-const { setCurrentlyPlayingPodcastEpisode } = usePlaybackQueue()
 const router = useRouter()
 
 const episodeDownloadedLocal = ref(false)
@@ -117,6 +115,9 @@ onBeforeMount(async () => {
           <div class="flex flex-row gap-2">
             <ZButton
               :size12="true"
+              :hover-text="episode.status === 'completed'
+                ? episodeDownloadedLocal ? 'Episode downloaded locally' : 'Episode downloaded on server'
+                : episode.status === 'downloading' ? 'Downloading...' : 'Download episode on server'"
               @click="downloadEpisode()"
             >
               <Loading
@@ -148,12 +149,11 @@ onBeforeMount(async () => {
           </div>
         </div>
       </div>
-      <ZButton
-        class="my-auto size-14"
-        @click="setCurrentlyPlayingPodcastEpisode(episode)"
-      >
-        <icon-nrk-media-play class="size-12 footer-icon" />
-      </ZButton>
+      <PlayButton
+        :podcast="episode"
+        class="my-auto"
+        hover-text="Play episode"
+      />
     </div>
     <div class="line-clamp-4 overflow-hidden text-ellipsis whitespace-pre-line text-pretty">
       {{ descriptionLinesCleaned }}

--- a/frontend/src/components/RefreshHeader.vue
+++ b/frontend/src/components/RefreshHeader.vue
@@ -18,9 +18,9 @@ async function refresh() {
 </script>
 
 <template>
-  <div class="flex flex-row items-center justify-center gap-x-2 py-6 md:justify-start">
+  <div class="flex flex-row items-center justify-center gap-x-2 py-6 lg:justify-start">
     <ZButton @click="emits('titleClick')">
-      <span class="text-sm md:text-base">{{ title }}</span>
+      <span class="text-sm lg:text-base">{{ title }}</span>
     </ZButton>
     <icon-nrk-refresh class="cursor-pointer text-sm hover:text-primary2" :class="{ spin: refreshed }" @click="refresh()" />
   </div>

--- a/frontend/src/components/SettingsDropDown.vue
+++ b/frontend/src/components/SettingsDropDown.vue
@@ -45,26 +45,26 @@ onBeforeUnmount(() => {
     <transition name="fade">
       <div
         v-if="open"
-        class="absolute right-0 mt-2 w-64 origin-top-right bg-white shadow-lg ring-1 ring-black ring-opacity-5 md:w-56"
+        class="absolute right-0 mt-2 w-64 origin-top-right bg-white shadow-lg ring-1 ring-black ring-opacity-5 lg:w-56"
       >
         <div class="py-1">
           <div
-            class="block cursor-pointer px-4 py-3 text-base text-gray-700 hover:bg-gray-100 md:py-2 md:text-sm"
+            class="block cursor-pointer px-4 py-3 text-base text-gray-700 hover:bg-gray-100 lg:py-2 lg:text-sm"
             @click="runScan"
           >
             Run a Scan
           </div>
           <div
-            class="block cursor-pointer px-4 py-3 text-base text-gray-700 hover:bg-gray-100 md:py-2 md:text-sm"
+            class="block cursor-pointer px-4 py-3 text-base text-gray-700 hover:bg-gray-100 lg:py-2 lg:text-sm"
             @click="toggleDebug()"
           >
             Debug: {{ useDebugBool ? 'On' : 'Off' }}
           </div>
-          <div class="px-4 py-3 md:py-2">
-            <label class="mb-2 block text-base text-gray-500 md:mb-1 md:text-sm">Stream Quality</label>
+          <div class="px-4 py-3 lg:py-2">
+            <label class="mb-2 block text-base text-gray-500 lg:mb-1 lg:text-sm">Stream Quality</label>
             <select
               v-model="streamQuality"
-              class="-md w-full border border-gray-300 px-3 py-2 text-base text-gray-700 md:px-2 md:py-1 md:text-sm focus:outline-none focus:ring focus:ring-blue-200"
+              class="-md w-full border border-gray-300 px-3 py-2 text-base text-gray-700 lg:px-2 lg:py-1 lg:text-sm focus:outline-none focus:ring focus:ring-blue-200"
             >
               <option
                 v-for="quality in StreamQualities"
@@ -77,7 +77,7 @@ onBeforeUnmount(() => {
           </div>
           <router-link
             to="/admin"
-            class="block px-4 py-3 text-base text-gray-700 hover:bg-gray-100 md:py-2 md:text-sm"
+            class="block px-4 py-3 text-base text-gray-700 hover:bg-gray-100 lg:py-2 lg:text-sm"
             @click="close"
           >
             Manage Users

--- a/frontend/src/components/TopGenres.vue
+++ b/frontend/src/components/TopGenres.vue
@@ -16,7 +16,7 @@ onBeforeMount(async () => {
 <template>
   <div>
     <RefreshHeader title="Top Genres" @refreshed="getGenres()" />
-    <div class="flex flex-wrap justify-center gap-2 overflow-hidden md:justify-start" :style="`max-height: calc(${(28 * 2) + 12}px);`">
+    <div class="flex flex-wrap justify-center gap-2 overflow-hidden lg:justify-start" :style="`max-height: calc(${(28 * 2) + 12}px);`">
       <GenreBottle v-for="genre in genres?.filter(g => g.value !== '')" :key="genre.value" :genre="genre.value" />
     </div>
   </div>

--- a/frontend/src/components/Tracks.vue
+++ b/frontend/src/components/Tracks.vue
@@ -124,7 +124,7 @@ watch(playcount_updated_musicbrainz_track_id, (newTrack) => {
 
 <template>
   <div class="corner-cut-large background-2">
-    <table class="h-full w-full p-4 text-left">
+    <table class="h-full w-full p-2 text-left lg:p-4">
       <thead>
         <tr class="text-lg text-muted">
           <th class="w-15 cursor-pointer text-center" @click="currentSortOption === 'trackNumberAsc' ? sortTracksBy('trackNumberDesc') : sortTracksBy('trackNumberAsc')">

--- a/frontend/src/components/Tracks.vue
+++ b/frontend/src/components/Tracks.vue
@@ -192,14 +192,14 @@ watch(playcount_updated_musicbrainz_track_id, (newTrack) => {
             <div class="flex shrink">
               <div class="flex flex-col px-2">
                 <RouterLink
-                  class="text-ellipsis text-lg text-primary no-underline hover:underline hover:underline-white"
+                  class="line-clamp-1 text-ellipsis text-lg text-primary no-underline hover:underline hover:underline-white"
                   :to="`/tracks/${track.id}`"
                   @click.stop
                 >
                   {{ track.title }}
                 </RouterLink>
                 <RouterLink
-                  class="text-sm text-muted no-underline hover:underline hover:underline-white"
+                  class="hidden text-sm text-muted no-underline lg:block hover:underline hover:underline-white"
                   :to="`/artists/${track.artistId}`"
                   @click.stop
                 >

--- a/frontend/src/components/UserManagement.vue
+++ b/frontend/src/components/UserManagement.vue
@@ -79,7 +79,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="p-4 md:p-6">
+  <div class="p-4 lg:p-6">
     <h1 class="mb-6 text-2xl font-semibold">
       Manage Users
     </h1>

--- a/frontend/src/components/ZButton.vue
+++ b/frontend/src/components/ZButton.vue
@@ -11,7 +11,7 @@ defineEmits(['click'])
 
 <template>
   <button
-    class="button-anchor group z-button relative inline-flex items-center align-middle"
+    class="group z-button relative inline-flex items-center align-middle"
     :disabled="disabled"
     :class="{
       'size-12': size12,
@@ -24,14 +24,3 @@ defineEmits(['click'])
     <slot />
   </button>
 </template>
-
-<style scoped>
-.button-anchor {
-  anchor-name: --button-anchor;
-}
-.tooltip {
-  position-anchor: --button-anchor;
-  top: anchor(top);
-  right: anchor(right);
-}
-</style>

--- a/frontend/src/components/ZButton.vue
+++ b/frontend/src/components/ZButton.vue
@@ -10,17 +10,19 @@ defineEmits(['click'])
 </script>
 
 <template>
-  <button
-    class="group z-button relative inline-flex items-center align-middle"
-    :disabled="disabled"
-    :class="{
-      'size-12': size12,
-      'cursor-not-allowed opacity-50': disabled,
-      'border-primary2': primary,
-      'border-zshade-600 dark:border-zshade-400': !primary,
-    }"
-    @click="$emit('click')"
-  >
-    <slot />
-  </button>
+  <abbr :title="hoverText" class="flex items-center align-middle">
+    <button
+      class="group z-button relative inline-flex items-center align-middle"
+      :disabled="disabled"
+      :class="{
+        'size-12': size12,
+        'cursor-not-allowed opacity-50': disabled,
+        'border-primary2': primary,
+        'border-zshade-600 dark:border-zshade-400': !primary,
+      }"
+      @click="$emit('click')"
+    >
+      <slot />
+    </button>
+  </abbr>
 </template>

--- a/frontend/src/pages/albums/[album].vue
+++ b/frontend/src/pages/albums/[album].vue
@@ -31,7 +31,7 @@ onUnmounted(() => clearRouteTracks())
 
 <template>
   <div v-if="album && tracks">
-    <div class="flex flex-grow flex-col gap-6">
+    <div class="flex flex-grow flex-col gap-4 lg:gap-6">
       <Album :album="album" size="md" :show-change-art-button="true" />
       <Tracks :tracks="tracks" />
     </div>

--- a/frontend/src/pages/artists/[artist].vue
+++ b/frontend/src/pages/artists/[artist].vue
@@ -115,7 +115,7 @@ onBeforeMount(async () => {
             <div class="text-7xl text-primary font-bold">
               {{ artist.name }}
             </div>
-            <div v-if="artistGenres.length > 0" class="flex flex-wrap justify-center gap-2 md:justify-start">
+            <div v-if="artistGenres.length > 0" class="flex flex-wrap justify-center gap-2 lg:justify-start">
               <GenreBottle v-for="genre in artistGenres" :key="genre" :genre="genre" />
             </div>
           </div>

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col">
-    <HeroAlbum class="hidden md:block" />
+    <HeroAlbum class="hidden lg:block" />
     <Albums :limit="50" sort-key="homePageAlbums" :limit-rows="true" />
     <Artists :limit="50" sort-key="homePageArtists" :limit-rows="true" />
     <TopGenres />

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex flex-col">
     <HeroAlbum class="hidden md:block" />
-    <Albums :limit="50" sort-key="homePageAlbums" :two-rows-only="true" />
-    <Artists :limit="50" sort-key="homePageArtists" :two-rows-only="true" />
+    <Albums :limit="50" sort-key="homePageAlbums" :limit-rows="true" />
+    <Artists :limit="50" sort-key="homePageArtists" :limit-rows="true" />
     <TopGenres />
   </div>
 </template>

--- a/frontend/src/pages/login.vue
+++ b/frontend/src/pages/login.vue
@@ -51,7 +51,7 @@ async function login() {
 </script>
 
 <template>
-  <div class="my-auto flex flex-col items-center justify-center gap-6 background-1 p-4 lg:flex-row lg:gap-12">
+  <div class="my-auto flex flex-col items-center justify-center gap-6 background-1 p-4 lg:(flex-row gap-12)">
     <img
       class="size-full max-w-400px opacity-90"
       src="/minidisk.svg"

--- a/frontend/src/pages/playlists/[playlist].vue
+++ b/frontend/src/pages/playlists/[playlist].vue
@@ -24,7 +24,7 @@ onBeforeMount(getPlaylist)
 
 <template>
   <div class="p-4 space-y-4">
-    <div v-if="playlist" class="flex flex-wrap justify-center gap-6 md:justify-start">
+    <div v-if="playlist" class="flex flex-wrap justify-center gap-6 lg:justify-start">
       <div>
         <img
           :src="playlist.coverArt"

--- a/frontend/src/pages/playlists/index.vue
+++ b/frontend/src/pages/playlists/index.vue
@@ -69,7 +69,7 @@ onBeforeMount(getPlaylists)
       <div v-if="playlists.length === 0" class="text-primary">
         No playlists found.
       </div>
-      <div class="flex flex-wrap justify-center gap-6 md:justify-start">
+      <div class="flex flex-wrap justify-center gap-6 lg:justify-start">
         <div
           v-for="(playlist, index) in playlists"
           :key="playlist.id" class="mx-auto max-w-60dvw flex flex-col items-center justify-center gap-4 transition duration-150 hover:scale-101"

--- a/frontend/src/pages/podcasts/[podcast].vue
+++ b/frontend/src/pages/podcasts/[podcast].vue
@@ -133,7 +133,7 @@ onBeforeMount(async () => {
               class="line-clamp-6 max-h-70 overflow-hidden text-ellipsis whitespace-pre-line text-pretty text-op-80"
               v-html="descriptionLinesCleaned"
             />
-            <div v-if="podcast.episode.length && podcast.episode[0].genres?.length > 0" class="flex flex-wrap justify-center gap-2 md:justify-start">
+            <div v-if="podcast.episode.length && podcast.episode[0].genres?.length > 0" class="flex flex-wrap justify-center gap-2 lg:justify-start">
               <ZInfo v-for="genre in podcast.episode[0].genres?.filter(g => g.name !== '')" :key="genre.name" :text="genre.name" />
             </div>
             <div>

--- a/frontend/src/pages/podcasts/episodes/[episode].vue
+++ b/frontend/src/pages/podcasts/episodes/[episode].vue
@@ -2,10 +2,8 @@
 import type { SubsonicPodcastEpisodesResponse } from '~/types/subsonic'
 import type { SubsonicPodcastEpisode } from '~/types/subsonicPodcasts'
 import { openSubsonicFetchRequest } from '~/composables/backendFetch'
-import { usePlaybackQueue } from '~/composables/usePlaybackQueue'
 
 const route = useRoute()
-const { setCurrentlyPlayingPodcastEpisode } = usePlaybackQueue()
 
 watch(() => route.params.episode, async () => {
   getEpisode()
@@ -55,12 +53,11 @@ onBeforeMount(async () => {
           <div v-if="episode.genres?.length > 0" class="flex flex-wrap justify-center gap-2 lg:justify-start">
             <ZInfo v-for="genre in episode.genres?.filter(g => g.name !== '')" :key="genre.name" :text="genre.name" />
           </div>
-          <ZButton
-            class="my-auto size-14"
-            @click="setCurrentlyPlayingPodcastEpisode(episode)"
-          >
-            <icon-nrk-media-play class="size-12 footer-icon" />
-          </ZButton>
+          <PlayButton
+            :podcast="episode"
+            class="my-auto"
+            hover-text="Play episode"
+          />
         </div>
       </div>
       <div

--- a/frontend/src/pages/podcasts/episodes/[episode].vue
+++ b/frontend/src/pages/podcasts/episodes/[episode].vue
@@ -52,7 +52,7 @@ onBeforeMount(async () => {
           <div class="text-4xl font-bold">
             {{ episode.title }}
           </div>
-          <div v-if="episode.genres?.length > 0" class="flex flex-wrap justify-center gap-2 md:justify-start">
+          <div v-if="episode.genres?.length > 0" class="flex flex-wrap justify-center gap-2 lg:justify-start">
             <ZInfo v-for="genre in episode.genres?.filter(g => g.name !== '')" :key="genre.name" :text="genre.name" />
           </div>
           <ZButton

--- a/frontend/src/pages/podcasts/index.vue
+++ b/frontend/src/pages/podcasts/index.vue
@@ -66,7 +66,7 @@ onBeforeMount(getPodcasts)
       <div v-if="podcasts.length === 0" class="text-primary">
         No podcasts found.
       </div>
-      <div class="flex flex-wrap justify-center gap-6 md:justify-start">
+      <div class="flex flex-wrap justify-center gap-6 lg:justify-start">
         <div
           v-for="(podcast, index) in podcasts"
           :key="podcast.id" class="corner-cut flex flex-row cursor-pointer gap-4 border-1 border-muted border-solid p-4 align-top transition duration-150 hover:scale-101"
@@ -88,7 +88,7 @@ onBeforeMount(getPodcasts)
               class="line-clamp-5 max-h-70 overflow-hidden text-ellipsis whitespace-pre-line text-pretty text-op-80"
               v-html="podcast.description.replaceAll(/\n/g, '<br>')"
             />
-            <div v-if="podcast.episode.length && podcast.episode[0].genres?.length > 0" class="flex flex-wrap justify-center gap-2 md:justify-start">
+            <div v-if="podcast.episode.length && podcast.episode[0].genres?.length > 0" class="flex flex-wrap justify-center gap-2 lg:justify-start">
               <ZInfo v-for="genre in podcast.episode[0].genres?.filter(g => g.name !== '')" :key="genre.name" :text="genre.name" />
             </div>
           </div>

--- a/frontend/src/pages/tracks/[track].vue
+++ b/frontend/src/pages/tracks/[track].vue
@@ -43,7 +43,7 @@ onMounted(async () => {
     <div v-if="error" class="text-accent1 text-center">
       {{ error }}
     </div>
-    <div v-if="track && !loading && !error" class="flex flex-col gap-8 md:flex-row">
+    <div v-if="track && !loading && !error" class="flex flex-col gap-8 lg:flex-row">
       <img
         v-if="coverArtUrl"
         :src="coverArtUrl"
@@ -51,7 +51,7 @@ onMounted(async () => {
         class="h-auto max-w-30vw w-full shadow-lg"
         @error="onImageError"
       >
-      <div class="flex flex-col md:w-2/3">
+      <div class="flex flex-col lg:w-2/3">
         <h1 class="mb-2 text-3xl text-primary font-bold">
           {{ track.title }}
         </h1>

--- a/frontend/uno.config.ts
+++ b/frontend/uno.config.ts
@@ -4,10 +4,10 @@ export default defineConfig({
   shortcuts: {
     'touch-target': 'min-h-11 min-w-11 flex items-center justify-center',
     'touch-button': 'touch-target cursor-pointer transition-colors duration-200',
-    'mobile-grid': 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
-    'mobile-padding': 'p-3 md:p-6',
-    'mobile-margin': 'm-3 md:m-6',
-    'mobile-gap': 'gap-3 md:gap-6',
+    'mobile-grid': 'grid grid-cols-1 lg:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+    'mobile-padding': 'p-3 lg:p-6',
+    'mobile-margin': 'm-3 lg:m-6',
+    'mobile-gap': 'gap-3 lg:gap-6',
     'corner-cut': 'rounded-tl-12px [corner-top-left-shape:_bevel]',
     'corner-cut-large': 'rounded-tl-36px [corner-top-left-shape:_bevel]',
     'text-primary': 'dark:text-zshade-100 text-zshade-900',
@@ -18,7 +18,7 @@ export default defineConfig({
     'background-grad-2': 'dark:from-zshade-800 from-zshade-200 bg-gradient-to-r',
     'background-3': 'dark:bg-zshade-700 bg-zshade-100',
     'z-button': 'border-1 border-solid relative font-semibold corner-cut flex cursor-pointer items-center justify-center cursor-pointer px-3 py-1 text-sm outline-none transition-all duration-200 text-muted background-2 hover:from-primary2 hover:text-primary hover:bg-gradient-to-br',
-    'footer-icon': 'scale-100 text-lg text-muted transition-all duration-100 hover:scale-130 group-hover/button:scale-130 md:text-xl sm:text-lg dark:hover:text-primary1 hover:text-primary1 dark:group-hover/button:text-primary1 group-hover/button:text-primary1',
+    'footer-icon': 'scale-100 text-lg text-muted transition-all duration-100 hover:scale-130 group-hover/button:scale-130 lg:text-xl sm:text-lg dark:hover:text-primary1 hover:text-primary1 dark:group-hover/button:text-primary1 group-hover/button:text-primary1',
     'auto-grid-6': '[grid-template-columns:repeat(auto-fit,minmax(min(150px,100%),1fr))] grid gap-6',
   },
   theme: {


### PR DESCRIPTION
This pull request focuses on improving the application's responsive design by shifting many layout and style breakpoints from medium (`md`) to large (`lg`) screens, enhancing the user experience on larger devices. Additionally, it introduces several UI/UX refinements, such as more consistent sizing, improved button accessibility, and better modal handling. There are also minor changes to variable naming and spell-check configuration.

**Responsive Design Improvements:**

* Changed most responsive breakpoints from `md` (medium) to `lg` (large) across multiple components, affecting grid layouts, paddings, font sizes, and visibility of elements to provide a more optimized layout for large screens. (`frontend/src/App.vue`, `frontend/src/components/Album.vue`, `frontend/src/components/ArtistThumb.vue`, `frontend/src/components/Artists.vue`, `frontend/src/components/FooterPlayer.vue`, `frontend/src/components/HeaderAndSearch.vue`, `frontend/src/components/HeroAlbum.vue`, `frontend/src/components/Navbar.vue`, `frontend/src/components/NavLink.vue`) [[1]](diffhunk://#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878L2-R5) [[2]](diffhunk://#diff-60b52a64aa13a53da32bccb3cfdf4e0dd6ad38b598437eb0a4a110725b6a1a46L101-R101) [[3]](diffhunk://#diff-60b52a64aa13a53da32bccb3cfdf4e0dd6ad38b598437eb0a4a110725b6a1a46L110-R138) [[4]](diffhunk://#diff-60b52a64aa13a53da32bccb3cfdf4e0dd6ad38b598437eb0a4a110725b6a1a46R147-R149) [[5]](diffhunk://#diff-4836b72fdac864595cd306b88e8b144840ebd9c7091c7df4835470b410a63c45L48-R48) [[6]](diffhunk://#diff-59de54519ff55d7352f9cd9a535f0e6fcd3e018978e361857139b801fc92c697L64-R75) [[7]](diffhunk://#diff-8b983779883a53e682729b3156bb55a168f32b7660a56b4f8a9e462eb8271a99L161-R163) [[8]](diffhunk://#diff-8b983779883a53e682729b3156bb55a168f32b7660a56b4f8a9e462eb8271a99L192-R192) [[9]](diffhunk://#diff-cd4e42ef3c2d4f3939f1e220a04e93d03cd12d8b93bca4e03c060bfe39db1e62L15-R22) [[10]](diffhunk://#diff-cd4e42ef3c2d4f3939f1e220a04e93d03cd12d8b93bca4e03c060bfe39db1e62L31-R47) [[11]](diffhunk://#diff-542ba89b960f30d418f3cd804b8530fbd1c8565843d9eb789cb7071e85b478a5L42-R42) [[12]](diffhunk://#diff-236d15dd716260bd9d97863630b51d50bfc0ef9da307cbade7bc770eec2c4641L11-R45) [[13]](diffhunk://#diff-236d15dd716260bd9d97863630b51d50bfc0ef9da307cbade7bc770eec2c4641L58-R57)

* Updated grid and height calculation logic in `Albums.vue` and `Artists.vue` to use a new `limitRows` prop (replacing `twoRowsOnly`) and improved handling of max-height for different screen sizes, including new scoped CSS for large screens. (`frontend/src/components/Albums.vue`, `frontend/src/components/Artists.vue`) [[1]](diffhunk://#diff-6479ab89cb3c18484058698340855ba6284563721191b3b4e73901c7356145f0L11-R11) [[2]](diffhunk://#diff-6479ab89cb3c18484058698340855ba6284563721191b3b4e73901c7356145f0L40-R48) [[3]](diffhunk://#diff-6479ab89cb3c18484058698340855ba6284563721191b3b4e73901c7356145f0L162-R167) [[4]](diffhunk://#diff-6479ab89cb3c18484058698340855ba6284563721191b3b4e73901c7356145f0R176-R183) [[5]](diffhunk://#diff-6dae65f999e63c0adc2366d73b471d04e0366234719490c679efc9df909faf44L11-R11) [[6]](diffhunk://#diff-6dae65f999e63c0adc2366d73b471d04e0366234719490c679efc9df909faf44R39-R50) [[7]](diffhunk://#diff-6dae65f999e63c0adc2366d73b471d04e0366234719490c679efc9df909faf44L123-R142) [[8]](diffhunk://#diff-6dae65f999e63c0adc2366d73b471d04e0366234719490c679efc9df909faf44R151-R158)

**UI/UX Enhancements:**

* Improved modal and button accessibility: replaced text "X" with an icon for closing modals, added hover text, and moved the close button in `LyricsModal.vue` to a more accessible position. (`frontend/src/components/ChangeAlbumArt.vue`, `frontend/src/components/LyricsModal.vue`) [[1]](diffhunk://#diff-53862350db1b0218cbed0b7bb1b4100045c7c63dcb60995d655c4edb3ff2637cL82-R83) [[2]](diffhunk://#diff-f20a74614d27e859be9cc3cf1211c9d566580e5be0d57bbabf740f0903254995R13-R18) [[3]](diffhunk://#diff-f20a74614d27e859be9cc3cf1211c9d566580e5be0d57bbabf740f0903254995R37-R46)

* Enhanced header and navigation: added tooltips to icons, improved alignment, and adjusted logo sizing for better clarity and usability. (`frontend/src/components/HeaderAndSearch.vue`, `frontend/src/components/Navbar.vue`) [[1]](diffhunk://#diff-cd4e42ef3c2d4f3939f1e220a04e93d03cd12d8b93bca4e03c060bfe39db1e62L15-R22) [[2]](diffhunk://#diff-cd4e42ef3c2d4f3939f1e220a04e93d03cd12d8b93bca4e03c060bfe39db1e62L31-R47) [[3]](diffhunk://#diff-236d15dd716260bd9d97863630b51d50bfc0ef9da307cbade7bc770eec2c4641L11-R45) [[4]](diffhunk://#diff-236d15dd716260bd9d97863630b51d50bfc0ef9da307cbade7bc770eec2c4641L58-R57)

**Minor Codebase Updates:**

* Renamed the `twoRowsOnly` prop to `limitRows` for clarity in both `Albums.vue` and `Artists.vue`. [[1]](diffhunk://#diff-6479ab89cb3c18484058698340855ba6284563721191b3b4e73901c7356145f0L11-R11) [[2]](diffhunk://#diff-6dae65f999e63c0adc2366d73b471d04e0366234719490c679efc9df909faf44L11-R11)

* Updated spell-check configuration to add "dvh" to the allowed words. (`cspell.json`)