### PR TITLE
view-transition/init

### DIFF
--- a/core/version/version.go
+++ b/core/version/version.go
@@ -3,7 +3,7 @@ package version
 import "zene/core/types"
 
 var Version = types.Version{
-	ServerVersion:          "26.6.0",
+	ServerVersion:          "26.7.0",
 	DatabaseVersion:        "151",
 	SubsonicApiVersion:     "1.16.1",
 	OpenSubsonicApiVersion: "1",

--- a/frontend/src/components/HeaderAndSearch.vue
+++ b/frontend/src/components/HeaderAndSearch.vue
@@ -1,10 +1,21 @@
 <script setup lang="ts">
-import { useDark, useToggle } from '@vueuse/core'
+import { useDark } from '@vueuse/core'
 import { toggleMobileNav } from '~/logic/navbar'
 import { getSearchResults, searchInput } from '~/logic/search'
 
 const isDark = useDark()
-const toggleDark = useToggle(isDark)
+
+function toggleDark() {
+  if (!document.startViewTransition) {
+    // Fallback for browsers that don't support view transitions
+    isDark.value = !isDark.value
+    return
+  }
+
+  document.startViewTransition(() => {
+    isDark.value = !isDark.value
+  })
+}
 </script>
 
 <template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,7 +5,9 @@ import { routes } from 'vue-router/auto-routes'
 import { closeSearch } from '~/logic/search'
 import { createEpisodeStoreIfNotExists } from '~/stores/usePodcastStore'
 import App from './App.vue'
+
 import 'virtual:uno.css'
+import '~/styles/themeTransition.css'
 
 const apiKey = useLocalStorage('apiKey', '')
 

--- a/frontend/src/styles/themeTransition.css
+++ b/frontend/src/styles/themeTransition.css
@@ -1,0 +1,12 @@
+::view-transition-old(root) {
+  animation-delay: 300ms;
+}
+
+::view-transition-new(root) {
+  animation: circle-in 800ms;
+}
+
+@keyframes circle-in {
+  from { clip-path: circle(5% at 100% 0%); }
+  to { clip-path: circle(150% at 100% 0%); }
+}

--- a/frontend/src/types/view-transitions.d.ts
+++ b/frontend/src/types/view-transitions.d.ts
@@ -1,0 +1,11 @@
+// Type declarations for View Transitions API
+interface Document {
+  startViewTransition?: (callback?: () => void | Promise<void>) => ViewTransition
+}
+
+interface ViewTransition {
+  finished: Promise<void>
+  ready: Promise<void>
+  updateCallbackDone: Promise<void>
+  skipTransition: () => void
+}


### PR DESCRIPTION
This pull request introduces a new animated theme transition when toggling dark mode in the frontend, improving the user experience with a smoother visual effect. It also updates the server version and adds the required CSS for the new transition.

**Frontend theme transition improvements:**

* Refactored the dark mode toggle in `HeaderAndSearch.vue` to use the browser's `startViewTransition` API when available, providing a smooth animated transition between themes, and included a fallback for browsers that don't support this API.
* Added a new stylesheet `themeTransition.css` with keyframes and view transition selectors to create a circular animation effect during theme changes.
* Imported the new `themeTransition.css` in `main.ts` to ensure the transition styles are applied globally.

**Version update:**

* Updated the `ServerVersion` in `version.go` from `26.6.0` to `26.7.0`.